### PR TITLE
Custom font and GetText improvements

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1494,6 +1494,12 @@ std::string TextEditor::GetSelectedText() const
 	return GetText(mState.mSelectionStart, mState.mSelectionEnd);
 }
 
+std::string TextEditor::GetCurrentLineText()const
+{
+	auto lineLength     = mLines[mState.mCursorPosition.mLine].size();
+	return GetText(Coordinates(mState.mCursorPosition.mLine, 0), Coordinates(mState.mCursorPosition.mLine, lineLength));
+}
+
 void TextEditor::ProcessInputs()
 {
 }

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -500,6 +500,9 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 			Cut();
 		else if (ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_A)))
 			SelectAll();
+		else if (!IsReadOnly() && !ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Enter)) )
+			EnterCharacter('\n');
+
 		/*
 			Add Input Characters
 		*/

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 
 #include "TextEditor.h"
-
+#include "imgui_internal.h" // for imGui::GetCurrentWindow()
 
 // TODO
 // - multiline comments vs single-line: latter is blocking start of a ML

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -432,6 +432,9 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 	const float fontSize = ImGui::GetCurrentWindow()->CalcFontSize();
 	mCharAdvance = ImVec2(fontSize , ImGui::GetTextLineHeightWithSpacing() * mLineSpacing);	
 
+	/*
+		Keyboard inputs
+	*/
 
 	ImGui::PushAllowKeyboardFocus(true);
 	ImGuiIO& io = ImGui::GetIO();
@@ -497,6 +500,9 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 			Cut();
 		else if (ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_A)))
 			SelectAll();
+		/*
+			Add Input Characters
+		*/
 
 		if (!IsReadOnly())
 		{
@@ -516,15 +522,24 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 		}
 	}
 
+	/*
+		Mouse inputs
+	*/
+
 	if (ImGui::IsWindowHovered())
 	{
 		static float lastClick = -1.0f;
 		if (!shift && !alt)
 		{
-			auto click = ImGui::IsMouseClicked(0);
+			auto click       = ImGui::IsMouseClicked(0);
 			auto doubleClick = ImGui::IsMouseDoubleClicked(0);
-			auto t = ImGui::GetTime();
+			auto t           = ImGui::GetTime();
 			auto tripleClick = click && !doubleClick && t - lastClick < io.MouseDoubleClickTime;
+
+			/*
+				Left mouse button triple click
+			*/
+
 			if (tripleClick)
 			{
 				printf("triple\n");
@@ -537,6 +552,11 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 
 				lastClick = -1.0f;
 			}
+
+			/*
+				Left mouse button double click
+			*/
+
 			else if (doubleClick)
 			{
 				printf("double\n");
@@ -552,6 +572,11 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 
 				lastClick = ImGui::GetTime();
 			}
+
+			/*
+				Left mouse button click
+			*/
+
 			else if (click)
 			{
 				printf("single\n");
@@ -564,19 +589,18 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 
 				lastClick = ImGui::GetTime();
 			}
+
+			/*
+				Mouse left button dragging (=> update selection)
+			*/
+
 			else if (ImGui::IsMouseDragging(0) && ImGui::IsMouseDown(0))
 			{
 				io.WantCaptureMouse = true;
 				mState.mCursorPosition = mInteractiveEnd = SanitizeCoordinates(ScreenPosToCoordinates(ImGui::GetMousePos()));
 				SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
 			}
-			else
-			{
-			}
 		}
-
-		//if (!ImGui::IsMouseDown(0))
-		//	mWordSelectionMode = false;
 	}
 
 	ColorizeInternal();
@@ -611,6 +635,10 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 			Coordinates lineStartCoord(lineNo, 0);
 			Coordinates lineEndCoord(lineNo, (int)line.size());
 
+			/*
+				Draw Selected area 
+			*/
+
 			int sstart = -1;
 			int ssend = -1;
 
@@ -630,6 +658,10 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 				drawList->AddRectFilled(vstart, vend, mPalette[(int)PaletteIndex::Selection]);
 			}
 
+			/*
+				Draw break point
+			*/
+
 			static char buf[16];
 			auto start = ImVec2(lineStartScreenPos.x + scrollX, lineStartScreenPos.y);
 
@@ -638,6 +670,10 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 				auto end = ImVec2(lineStartScreenPos.x + contentSize.x + 2.0f * scrollX, lineStartScreenPos.y + mCharAdvance.y);
 				drawList->AddRectFilled(start, end, mPalette[(int)PaletteIndex::Breakpoint]);
 			}
+
+			/*
+				Draw error marker
+			*/
 
 			auto errorIt = mErrorMarkers.find(lineNo + 1);
 			if (errorIt != mErrorMarkers.end())
@@ -692,6 +728,10 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 					}
 				}
 			}
+
+			/*
+				Draw Text
+			*/
 
 			appendIndex = 0;
 			auto prevColor = line.empty() ? PaletteIndex::Default : (line[0].mMultiLineComment ? PaletteIndex::MultiLineComment : line[0].mColorIndex);

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -6,7 +6,6 @@
 
 #include "TextEditor.h"
 
-static const int cTextStart = 7;
 
 // TODO
 // - multiline comments vs single-line: latter is blocking start of a ML

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -698,9 +698,16 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 				}
 			}
 
-			auto chars = snprintf(buf, 16, "%6d", lineNo + 1);
-			assert(chars >= 0 && chars < 16);
-			drawList->AddText(ImVec2(lineStartScreenPos.x /*+ mCharAdvance.x * 1*/, lineStartScreenPos.y), mPalette[(int)PaletteIndex::LineNumber], buf);
+			/*
+				Draw line number (right aligned)
+			*/
+			std::string lineAsString(std::to_string(lineNo));
+			auto lineAsStringWidth = ImGui::CalcTextSize(lineAsString.c_str()).x;
+			drawList->AddText(ImVec2(mTextStart - lineAsStringWidth, lineStartScreenPos.y), mPalette[(int)PaletteIndex::LineNumber], lineAsString.c_str());
+
+			/*
+				Highlight the current line (where the cursor is).
+			*/
 
 			if (mState.mCursorPosition.mLine == lineNo)
 			{

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <map>
 #include <regex>
-#include "imgui.h"
+#include <imgui/imgui.h>
 
 class TextEditor
 {

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -273,7 +273,7 @@ private:
 	void Colorize(int aFromLine = 0, int aCount = -1);
 	void ColorizeRange(int aFromLine = 0, int aToLine = 0);
 	void ColorizeInternal();
-	int TextDistanceToLineStart(const Coordinates& aFrom) const;
+	float TextDistanceToLineStart(const Coordinates& aFrom) const;
 	void EnsureCursorVisible();
 	int GetPageSize() const;
 	int AppendBuffer(std::string& aBuffer, char chr, int aIndex);

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -185,6 +185,7 @@ public:
 	void SetReadOnly(bool aValue);
 	bool IsReadOnly() const { return mReadOnly; }
 	bool IsTextChanged() const { return mTextChanged; }
+	bool IsCursorPositionChanged() const { return mCursorPositionChanged; }
 
 	Coordinates GetCursorPosition() const { return GetActualCursorCoordinates(); }
 	void SetCursorPosition(const Coordinates& aPosition);
@@ -307,6 +308,7 @@ private:
 	bool mWithinRender;
 	bool mScrollToCursor;
 	bool mTextChanged;
+	bool mCursorPositionChanged;
 	int mColorRangeMin, mColorRangeMax;
 	SelectionMode mSelectionMode;
 

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -129,7 +129,7 @@ public:
 	struct Glyph
 	{
 		Char mChar;
-		PaletteIndex mColorIndex : 7;
+		PaletteIndex mColorIndex = PaletteIndex::Default;
 		bool mMultiLineComment : 1;
 
 		Glyph(Char aChar, PaletteIndex aColorIndex) : mChar(aChar), mColorIndex(aColorIndex), mMultiLineComment(false) {}

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -308,6 +308,8 @@ private:
 	bool mWithinRender;
 	bool mScrollToCursor;
 	bool mTextChanged;
+	int  mTextStart;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
+	int  mLeftMargin;
 	bool mCursorPositionChanged;
 	int mColorRangeMin, mColorRangeMax;
 	SelectionMode mSelectionMode;

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <map>
 #include <regex>
-#include <imgui/imgui.h>
+#include "imgui.h"
 
 class TextEditor
 {

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -178,7 +178,8 @@ public:
 	void SetText(const std::string& aText);
 	std::string GetText() const;
 	std::string GetSelectedText() const;
-
+	std::string GetCurrentLineText()const;
+	
 	int GetTotalLines() const { return (int)mLines.size(); }
 	bool IsOverwrite() const { return mOverwrite; }
 


### PR DESCRIPTION
In this PR you can find these modifications :

- non fixed-sized font handling.
- Improvements in line number drawing (reserve a minimal space regarding to total line count).
- Adding comments to easily read Render() method.
- Added new method to know if cursor position changed.
- Added a new method to get the current line text.

I tested it on linux only with the default font and with an other fond with non fixed width chars.

Sorry for the first commit relative to imgui.h, I've reverted it in a more recent one.
