### PR TITLE
FIX: Undo caused crash when inserting newline at the end of text

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -192,16 +192,23 @@ int TextEditor::InsertTextAt(Coordinates& /* inout */ aWhere, const char * aValu
 		}
 		else if (chr == '\n')
 		{
-			if (aWhere.mColumn < (int)mLines[aWhere.mLine].size())
+			if (aWhere.mLine < mLines.size())
 			{
-				auto& newLine = InsertLine(aWhere.mLine + 1);
-				auto& line = mLines[aWhere.mLine];
-				newLine.insert(newLine.begin(), line.begin() + aWhere.mColumn, line.end());
-				line.erase(line.begin() + aWhere.mColumn, line.end());
+				if (aWhere.mColumn < (int)mLines[aWhere.mLine].size())
+				{
+					auto& newLine = InsertLine(aWhere.mLine + 1);
+					auto& line = mLines[aWhere.mLine];
+					newLine.insert(newLine.begin(), line.begin() + aWhere.mColumn, line.end());
+					line.erase(line.begin() + aWhere.mColumn, line.end());
+				}
+				else
+				{
+					InsertLine(aWhere.mLine + 1);
+				}
 			}
 			else
 			{
-				InsertLine(aWhere.mLine + 1);
+				InsertLine(aWhere.mLine);
 			}
 			++aWhere.mLine;
 			aWhere.mColumn = 0;


### PR DESCRIPTION
Line 195 causes "vector subscript out of range" when undoing a newline on the last line.
Unsure if this is a proper fix or if it could be made better.