### PR TITLE
Fix for scrollbar jitter.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -414,7 +414,7 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 
 	ImGui::PushStyleColor(ImGuiCol_ChildWindowBg, ImGui::ColorConvertU32ToFloat4(mPalette[(int)PaletteIndex::Background]));
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 0.0f));
-	ImGui::BeginChild(aTitle, aSize, aBorder, ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_NoMove);
+	ImGui::BeginChild(aTitle, aSize, aBorder, ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_AlwaysHorizontalScrollbar | ImGuiWindowFlags_NoMove);
 
 	ImGui::PushAllowKeyboardFocus(true);
 


### PR DESCRIPTION
Hi,

I made a fix to avoid the scroll position from jumping around while scrolling. I just saw this behavior running the demo and thought I'd fix it. :-)

The solution is to always show the horizontal scrollbar, as the appearance/disappearance is what causes the content area to resize and the scrollbar to jump around.