### PR TITLE
Fix for assert/crash on SetText with empty string. Always just add the first line.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -745,10 +745,9 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 void TextEditor::SetText(const std::string & aText)
 {
 	mLines.clear();
+	mLines.push_back(Line());
 	for (auto chr : aText)
 	{
-		if (mLines.empty())
-			mLines.push_back(Line());
 		if (chr == '\n')
 			mLines.push_back(Line());
 		else


### PR DESCRIPTION
After I wrote this fix I saw there was already a pull request with a fix for this (https://github.com/BalazsJako/ImGuiColorTextEdit/pull/34/files), but this one is more elegant I think, as it makes it a 'rule' there's always at least one line. I will add a PR with further enforcement of this rule, removing some not so pretty fixes in other places that were already there.