### PR TITLE
Keyboard input handling improvements

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -419,8 +419,8 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 	ImGui::PushAllowKeyboardFocus(true);
 
 	auto shift = io.KeyShift;
-	auto ctrl = io.KeyCtrl;
-	auto alt = io.KeyAlt;
+	auto ctrl = io.OptMacOSXBehaviors ? io.KeySuper : io.KeyCtrl;
+	auto alt = io.OptMacOSXBehaviors ? io.KeyCtrl : io.KeyAlt;
 
 	if (ImGui::IsWindowFocused())
 	{
@@ -481,7 +481,7 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 		else if (ctrl && !shift && !alt && ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_A)))
 			SelectAll();
 
-		if (!IsReadOnly())
+		if (!IsReadOnly() && !ctrl && !alt)
 		{
 			for (size_t i = 0; i < sizeof(io.InputCharacters) / sizeof(io.InputCharacters[0]); i++)
 			{


### PR DESCRIPTION
- Added OSX behaviors for 'control' and 'alt'. On Macos the 'apple' (super) key is used for copy-pasting etc, and 'alt' is mapped to 'control' (option doesn't work, perhaps because it activates Macos' menus?). Anyway, these keys are reversed so on Macos I swapped their behaviors.

- Don't interpret key presses as regular text entry when control or alt is pressed. This caused the letter 'z' to appear when triggering undo for instance.