### PR TITLE
Ignore carriage return when SetText is called

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -821,7 +821,11 @@ void TextEditor::SetText(const std::string & aText)
 	mLines.push_back(Line());
 	for (auto chr : aText)
 	{
-		if (chr == '\n')
+		if (chr == '\r')
+		{
+			// ignore the carriage return character
+		}
+		else if (chr == '\n')
 			mLines.push_back(Line());
 		else
 		{


### PR DESCRIPTION
This makes sure Windows formatted text files (which use CR+LF) are handled correctly. Currently in the demo many lines get an invisible space-like character added to the end of the line, because the '\r' character (which is non-visible) is added to the end of the line. This change makes sure those are gone.