### PR TITLE
(Very basic) automatic indentation for some languages

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -863,8 +863,13 @@ void TextEditor::EnterCharacter(Char aChar)
 		InsertLine(coord.mLine + 1);
 		auto& line = mLines[coord.mLine];
 		auto& newLine = mLines[coord.mLine + 1];
-		for (size_t it = 0; it < line.size() && isblank(line[it].mChar); ++it)
-			newLine.push_back(line[it]);
+		
+		if (mLanguageDefinition.mAutoIndentation)
+		{
+			for (size_t it = 0; it < line.size() && isblank(line[it].mChar); ++it)
+				newLine.push_back(line[it]);
+		}
+		
 		const size_t whitespaceSize = newLine.size();
 		newLine.insert(newLine.end(), line.begin() + coord.mColumn, line.end());
 		line.erase(line.begin() + coord.mColumn, line.begin() + line.size());
@@ -1889,6 +1894,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::CPlusPlus()
 		langDef.mCommentEnd = "*/";
 
 		langDef.mCaseSensitive = true;
+		langDef.mAutoIndentation = true;
 
 		langDef.mName = "C++";
 
@@ -1960,6 +1966,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::HLSL()
 		langDef.mCommentEnd = "*/";
 
 		langDef.mCaseSensitive = true;
+		langDef.mAutoIndentation = true;
 
 		langDef.mName = "HLSL";
 
@@ -2008,6 +2015,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::GLSL()
 		langDef.mCommentEnd = "*/";
 
 		langDef.mCaseSensitive = true;
+		langDef.mAutoIndentation = true;
 
 		langDef.mName = "GLSL";
 
@@ -2056,6 +2064,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::C()
 		langDef.mCommentEnd = "*/";
 
 		langDef.mCaseSensitive = true;
+		langDef.mAutoIndentation = true;
 
 		langDef.mName = "C";
 
@@ -2119,6 +2128,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::SQL()
 		langDef.mCommentEnd = "*/";
 
 		langDef.mCaseSensitive = false;
+		langDef.mAutoIndentation = false;
 
 		langDef.mName = "SQL";
 
@@ -2168,6 +2178,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::AngelScript()
 		langDef.mCommentEnd = "*/";
 
 		langDef.mCaseSensitive = true;
+		langDef.mAutoIndentation = true;
 
 		langDef.mName = "AngelScript";
 
@@ -2221,6 +2232,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::Lua()
 		langDef.mCommentEnd = "\\]\\]";
 
 		langDef.mCaseSensitive = true;
+		langDef.mAutoIndentation = false;
 
 		langDef.mName = "Lua";
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -863,9 +863,12 @@ void TextEditor::EnterCharacter(Char aChar)
 		InsertLine(coord.mLine + 1);
 		auto& line = mLines[coord.mLine];
 		auto& newLine = mLines[coord.mLine + 1];
-		newLine.insert(newLine.begin(), line.begin() + coord.mColumn, line.end());
+		for (size_t it = 0; it < line.size() && isblank(line[it].mChar); ++it)
+			newLine.push_back(line[it]);
+		const size_t whitespaceSize = newLine.size();
+		newLine.insert(newLine.end(), line.begin() + coord.mColumn, line.end());
 		line.erase(line.begin() + coord.mColumn, line.begin() + line.size());
-		SetCursorPosition(Coordinates(coord.mLine + 1, 0));
+		SetCursorPosition(Coordinates(coord.mLine + 1, (int)whitespaceSize));
 	}
 	else
 	{

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -152,6 +152,7 @@ public:
 		TokenRegexStrings mTokenRegexStrings;
 
 		bool mCaseSensitive;
+		bool mAutoIndentation;
 
 		static LanguageDefinition CPlusPlus();
 		static LanguageDefinition HLSL();


### PR DESCRIPTION
Hi,

I've added some very basic indentation support. Whether it's enabled or not is language definition dependent. I enabled it for all "C" style languages (C, C++, GLSL, GLSL, AngelScript). I left it off for SQL and Lua (for which I'm not very familiar with the indentation conventions for that language).

For now the behavior is very simple. It copies the indentation of the last line when adding a new one after the user adds a return character. It's very basic, but it allows one to continue typing at the same indentation level, which is more convenient than having to apply indentation over and over again. :-)

Also, this change opens up the way for more advanced ('intelligent') indentation rules.

Thank you for looking into my changes and merging them. Much appreciated!

Cheers,
Marcel