### PR TITLE
Fast syntax highlighting for C and C++

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1761,7 +1761,7 @@ void TextEditor::ColorizeInternal()
 		mCheckMultilineComments = false;
 		return;
 	}
-	
+
 	if (mColorRangeMin < mColorRangeMax)
 	{
 		const int increment = (mLanguageDefinition.mTokenize == nullptr) ? 10 : 10000;
@@ -2163,7 +2163,7 @@ static bool tokenize_cstyle_punctuation(const char * in_begin, const char * in_e
 	return false;
 }
 
-TextEditor::LanguageDefinition TextEditor::LanguageDefinition::CPlusPlus()
+const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::CPlusPlus()
 {
 	static bool inited = false;
 	static LanguageDefinition langDef;
@@ -2234,7 +2234,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::CPlusPlus()
 	return langDef;
 }
 
-TextEditor::LanguageDefinition TextEditor::LanguageDefinition::HLSL()
+const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::HLSL()
 {
 	static bool inited = false;
 	static LanguageDefinition langDef;
@@ -2305,7 +2305,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::HLSL()
 	return langDef;
 }
 
-TextEditor::LanguageDefinition TextEditor::LanguageDefinition::GLSL()
+const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::GLSL()
 {
 	static bool inited = false;
 	static LanguageDefinition langDef;
@@ -2353,7 +2353,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::GLSL()
 	return langDef;
 }
 
-TextEditor::LanguageDefinition TextEditor::LanguageDefinition::C()
+const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::C()
 {
 	static bool inited = false;
 	static LanguageDefinition langDef;
@@ -2421,7 +2421,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::C()
 	return langDef;
 }
 
-TextEditor::LanguageDefinition TextEditor::LanguageDefinition::SQL()
+const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::SQL()
 {
 	static bool inited = false;
 	static LanguageDefinition langDef;
@@ -2484,7 +2484,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::SQL()
 	return langDef;
 }
 
-TextEditor::LanguageDefinition TextEditor::LanguageDefinition::AngelScript()
+const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::AngelScript()
 {
 	static bool inited = false;
 	static LanguageDefinition langDef;
@@ -2533,7 +2533,7 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::AngelScript()
 	return langDef;
 }
 
-TextEditor::LanguageDefinition TextEditor::LanguageDefinition::Lua()
+const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::Lua()
 {
 	static bool inited = false;
 	static LanguageDefinition langDef;

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -668,7 +668,7 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 
 			auto start = ImVec2(lineStartScreenPos.x + scrollX, lineStartScreenPos.y);
 
-			if (mBreakpoints.find(lineNo + 1) != mBreakpoints.end())
+			if (mBreakpoints.count(lineNo + 1) != 0)
 			{
 				auto end = ImVec2(lineStartScreenPos.x + contentSize.x + 2.0f * scrollX, lineStartScreenPos.y + mCharAdvance.y);
 				drawList->AddRectFilled(start, end, mPalette[(int)PaletteIndex::Breakpoint]);
@@ -1659,16 +1659,16 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine)
 
 					if (!preproc)
 					{
-						if (mLanguageDefinition.mKeywords.find(id) != mLanguageDefinition.mKeywords.end())
+						if (mLanguageDefinition.mKeywords.count(id) != 0)
 							token_color = PaletteIndex::Keyword;
-						else if (mLanguageDefinition.mIdentifiers.find(id) != mLanguageDefinition.mIdentifiers.end())
+						else if (mLanguageDefinition.mIdentifiers.count(id) != 0)
 							token_color = PaletteIndex::KnownIdentifier;
-						else if (mLanguageDefinition.mPreprocIdentifiers.find(id) != mLanguageDefinition.mPreprocIdentifiers.end())
+						else if (mLanguageDefinition.mPreprocIdentifiers.count(id) != 0)
 							token_color = PaletteIndex::PreprocIdentifier;
 					}
 					else
 					{
-						if (mLanguageDefinition.mPreprocIdentifiers.find(id) != mLanguageDefinition.mPreprocIdentifiers.end())
+						if (mLanguageDefinition.mPreprocIdentifiers.count(id) != 0)
 							token_color = PaletteIndex::PreprocIdentifier;
 						else
 							token_color = PaletteIndex::Identifier;
@@ -1761,7 +1761,7 @@ void TextEditor::ColorizeInternal()
 		mCheckMultilineComments = false;
 		return;
 	}
-
+	
 	if (mColorRangeMin < mColorRangeMax)
 	{
 		const int increment = (mLanguageDefinition.mTokenize == nullptr) ? 10 : 10000;
@@ -2005,7 +2005,7 @@ static bool tokenize_cstyle_identifier(const char * in_begin, const char * in_en
 {
 	const char * p = in_begin;
 	
-	if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z'))
+	if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || *p == '_')
 	{
 		p++;
 		

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1703,7 +1703,7 @@ void TextEditor::ColorizeInternal()
 			auto& line = mLines[i.mLine];
 			if (!line.empty())
 			{
-				auto g = line[i.mColumn];
+				auto& g = line[i.mColumn];
 				auto c = g.mChar;
 
 				bool inComment = commentStart <= i;
@@ -1902,16 +1902,134 @@ void TextEditor::UndoRecord::Redo(TextEditor * aEditor)
 	aEditor->EnsureCursorVisible();
 }
 
+static bool tokenize_cstyle_comment(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end)
+{
+	if (*in_begin != '/')
+		return false;
+	
+	if (in_begin + 1 < in_end && in_begin[1] == '/')
+	{
+		out_begin = in_begin;
+		out_end = in_end;
+		return true;
+	}
+	
+	return false;
+}
+
+static bool tokenize_cstyle_preprocessor_directive(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end)
+{
+	if (*in_begin != '#')
+		return false;
+	
+	const char * p = in_begin + 1;
+	
+	while (p < in_end && isblank(*p))
+		p++;
+	
+	bool hasText = false;
+	
+	while (p < in_end && ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || *p == '_'))
+	{
+		hasText = true;
+		p++;
+	}
+	
+	if (hasText)
+	{
+		out_begin = in_begin;
+		out_end = p;
+		return true;
+	}
+	
+	return false;
+}
+
+static bool tokenize_cstyle_string(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end)
+{
+	const char * p = in_begin;
+	
+	if (*p == '"')
+	{
+		p++;
+		
+		while (p < in_end)
+		{
+			// handle end of string
+			if (*p == '"')
+			{
+				out_begin = in_begin;
+				out_end = p + 1;
+				return true;
+			}
+			
+			// handle escape character for "
+			if (*p == '\\' && p + 1 < in_end && p[1] == '"')
+				p++;
+			
+			p++;
+		}
+	}
+	
+	return false;
+}
+
+static bool tokenize_cstyle_character_literal(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end)
+{
+	const char * p = in_begin;
+
+	if (*p == '\'')
+	{
+		p++;
+		
+		// handle escape characters
+		if (p < in_end && *p == '\\')
+			p++;
+		
+		if (p < in_end)
+			p++;
+		
+		// handle end of character literal
+		if (p < in_end && *p == '\'')
+		{
+			out_begin = in_begin;
+			out_end = p + 1;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool tokenize_cstyle_identifier(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end)
+{
+	const char * p = in_begin;
+	
+	if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z'))
+	{
+		p++;
+		
+		while ((p < in_end) && ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || (*p >= '0' && *p <= '9') || *p == '_'))
+			p++;
+		
+		out_begin = in_begin;
+		out_end = p;
+		return true;
+	}
+	
+	return false;
+}
+
 static bool tokenize_cstyle_number(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end)
 {
-	const char first_char = *in_begin;
+	const char * p = in_begin;
 	
-	const bool startsWithNumber = first_char >= '0' && first_char <= '9';
+	const bool startsWithNumber = *p >= '0' && *p <= '9';
 	
-	if (first_char != '+' && first_char != '-' && !startsWithNumber)
+	if (*p != '+' && *p != '-' && !startsWithNumber)
 		return false;
-
-	const char * p = in_begin + 1;
+	
+	p++;
 	
 	while (p < in_end && isblank(*p))
 		p++;
@@ -1929,52 +2047,120 @@ static bool tokenize_cstyle_number(const char * in_begin, const char * in_end, c
 		return false;
 	
 	bool isFloat = false;
+	bool isHex = false;
+	bool isBinary = false;
 	
-	if (p < in_end && *p == '.')
+	if (p < in_end)
 	{
-		isFloat = true;
-		
-		p++;
-		
-		while (p < in_end && (*p >= '0' && *p <= '9'))
-			p++;
-	}
-	
-	if (p < in_end && (*p == 'e' || *p == 'E'))
-	{
-		isFloat = false;
-		
-		p++;
-		
-		if (p < in_end && (*p == '+' || *p == '-'))
-			p++;
-		
-		bool hasDigits = false;
-		
-		while (p < in_end && (*p >= '0' && *p <= '9'))
+		if (*p == '.')
 		{
-			hasDigits = true;
+			isFloat = true;
 			
 			p++;
+			
+			while (p < in_end && (*p >= '0' && *p <= '9'))
+				p++;
 		}
-		
-		if (hasDigits == false)
-			return false;
+		else if (*p == 'x' || *p == 'X')
+		{
+			// hex formatted integer of the type 0xef80
+			
+			isHex = true;
+			
+			p++;
+			
+			while (p < in_end && ((*p >= '0' && *p <= '9') || (*p >= 'a' && *p <= 'f') || (*p >= 'A' && *p <= 'F')))
+				p++;
+		}
+		else if (*p == 'b' || *p == 'B')
+		{
+			// binary formatted integer of the type 0b01011101
+			
+			isBinary = true;
+			
+			p++;
+			
+			while (p < in_end && (*p >= '0' && *p <= '1'))
+				p++;
+		}
 	}
 	
-	if (p < in_end && *p == 'f')
-		p++;
+	if (isHex == false && isBinary == false)
+	{
+		// floating point exponent
+		if (p < in_end && (*p == 'e' || *p == 'E'))
+		{
+			isFloat = true;
+			
+			p++;
+			
+			if (p < in_end && (*p == '+' || *p == '-'))
+				p++;
+			
+			bool hasDigits = false;
+			
+			while (p < in_end && (*p >= '0' && *p <= '9'))
+			{
+				hasDigits = true;
+				
+				p++;
+			}
+			
+			if (hasDigits == false)
+				return false;
+		}
+		
+		// single precision floating point type
+		if (p < in_end && *p == 'f')
+			p++;
+	}
 	
 	if (isFloat == false)
 	{
+		// integer size type
 		while (p < in_end && (*p == 'u' || *p == 'U' || *p == 'l' || *p == 'L'))
-		
 			p++;
 	}
 	
 	out_begin = in_begin;
 	out_end = p;
 	return true;
+}
+
+static bool tokenize_cstyle_punctuation(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end)
+{
+	switch (*in_begin)
+	{
+		case '[':
+		case ']':
+		case '{':
+		case '}':
+		case '!':
+		case '%':
+		case '^':
+		case '&':
+		case '*':
+		case '(':
+		case ')':
+		case '-':
+		case '+':
+		case '=':
+		case '~':
+		case '|':
+		case '<':
+		case '>':
+		case '?':
+		case ':':
+		case '/':
+		case ';':
+		case ',':
+		case '.':
+			out_begin = in_begin;
+			out_end = in_begin + 1;
+			return true;
+	}
+	
+	return false;
 }
 
 TextEditor::LanguageDefinition TextEditor::LanguageDefinition::CPlusPlus()
@@ -2017,172 +2203,47 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::CPlusPlus()
 				paletteIndex = PaletteIndex::Default;
 				return true;
 			}
-		
-			const char first_char = *in_begin;
-			
-		#if 0
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("//.*", PaletteIndex::Comment));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[ \\t]*#[ \\t]*[a-zA-Z_]+", PaletteIndex::Preprocessor));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::CharLiteral));
-			langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-			//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
-		#endif
-		
-			// single-line comment
-			if (first_char == '/')
+			else if (tokenize_cstyle_comment(in_begin, in_end, out_begin, out_end))
 			{
-				if (in_begin + 1 < in_end && in_begin[1] == '/')
-				{
-					out_begin = in_begin;
-					out_end = in_end;
-					paletteIndex = PaletteIndex::Comment;
-					return true;
-				}
+				paletteIndex = PaletteIndex::Comment;
+				return true;
 			}
-			
-			// preprocessor directive
-			else if (first_char == '#')
+			else if (tokenize_cstyle_preprocessor_directive(in_begin, in_end, out_begin, out_end))
 			{
-				const char * p = in_begin + 1;
-				
-				while (p < in_end && isblank(*p))
-					p++;
-				
-				bool hasText = false;
-				
-				while (p < in_end && ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || *p == '_'))
-				{
-					hasText = true;
-					p++;
-				}
-				
-				if (hasText)
-				{
-					out_begin = in_begin;
-					out_end = p;
-					paletteIndex = PaletteIndex::Preprocessor;
-					return true;
-				}
+				paletteIndex = PaletteIndex::Preprocessor;
+				return true;
 			}
-		
-			// string
-			else if (first_char == '"')
+			else if (tokenize_cstyle_string(in_begin, in_end, out_begin, out_end))
 			{
-				const char * p = in_begin + 1;
-				
-				while (p < in_end)
-				{
-					// handle end of string
-					if (*p == '"')
-					{
-						out_begin = in_begin;
-						out_end = p + 1;
-						paletteIndex = PaletteIndex::String;
-						return true;
-					}
-					
-					// handle escape character for "
-					if (*p == '\\' && p + 1 < in_end && p[1] == '"')
-						p++;
-					
-					p++;
-				}
+				paletteIndex = PaletteIndex::String;
+				return true;
 			}
-			
-			// character literal
-			else if (first_char == '\'')
+			else if (tokenize_cstyle_character_literal(in_begin, in_end, out_begin, out_end))
 			{
-				const char * p = in_begin + 1;
-				
-				// handle escape characters
-				if (p < in_end && *p == '\\')
-					p++;
-				
-				if (p < in_end)
-					p++;
-				
-				// handle end of character literal
-				if (p < in_end && *p == '\'')
-				{
-					out_begin = in_begin;
-					out_end = p + 1;
-					paletteIndex = PaletteIndex::CharLiteral;
-					return true;
-				}
+				paletteIndex = PaletteIndex::CharLiteral;
+				return true;
 			}
-		
-			// identifier
-			if ((first_char >= 'a' && first_char <= 'z') || (first_char >= 'A' && first_char <= 'Z'))
+			else if (tokenize_cstyle_identifier(in_begin, in_end, out_begin, out_end))
 			{
-				const char * p = in_begin + 1;
-				
-				while ((p < in_end) && ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || (*p >= '0' && *p <= '9') || *p == '_'))
-					p++;
-				
-				out_begin = in_begin;
-				out_end = p;
 				paletteIndex = PaletteIndex::Identifier;
 				return true;
 			}
-			
-			if (tokenize_cstyle_number(in_begin, in_end, out_begin, out_end))
+			else if (tokenize_cstyle_number(in_begin, in_end, out_begin, out_end))
 			{
 				paletteIndex = PaletteIndex::Number;
 				return true;
 			}
-	
-			// 'punctuation'
-			switch (first_char)
+			else if (tokenize_cstyle_punctuation(in_begin, in_end, out_begin, out_end))
 			{
-				case '[':
-				case ']':
-				case '{':
-				case '}':
-				case '!':
-				case '%':
-				case '^':
-				case '&':
-				case '*':
-				case '(':
-				case ')':
-				case '-':
-				case '+':
-				case '=':
-				case '~':
-				case '|':
-				case '<':
-				case '>':
-				case '?':
-				case ':':
-				case '/':
-				case ';':
-				case ',':
-				case '.':
-					out_begin = in_begin;
-					out_end = in_begin + 1;
-					paletteIndex = PaletteIndex::Punctuation;
-					return true;
+				paletteIndex = PaletteIndex::Punctuation;
+				return true;
 			}
-		
-			return false;
+			else
+			{
+				return false;
+			}
 		};
 		
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("//.*", PaletteIndex::Comment));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[ \\t]*#[ \\t]*[a-zA-Z_]+", PaletteIndex::Preprocessor));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::CharLiteral));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-		//langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
-
 		langDef.mCommentStart = "/*";
 		langDef.mCommentEnd = "*/";
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1579,6 +1579,7 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine)
 
 	std::string buffer;
 	std::cmatch results;
+	std::string id;
 	
 	int endLine = std::max(0, std::min((int)mLines.size(), aToLine));
 	for (int i = aFromLine; i < endLine; ++i)
@@ -1642,20 +1643,15 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine)
 			}
 			else
 			{
-				const size_t kMaxIdentifierLength = 100;
-				
 				const size_t token_length = token_end - token_begin;
 				
-				if (token_color == PaletteIndex::Identifier && token_length < kMaxIdentifierLength)
+				if (token_color == PaletteIndex::Identifier)
 				{
-					char id[kMaxIdentifierLength];
-					for (size_t i = 0; i < token_length; ++i)
-						id[i] = token_begin[i];
-					id[token_length] = 0;
+					id.assign(token_begin, token_end);
 					
 				// todo : allmost all language definitions use lower case to specify keywords, so shouldn't this use ::tolower ?
 					if (!mLanguageDefinition.mCaseSensitive)
-						std::transform(id, id + token_length, id, ::toupper);
+						std::transform(id.begin(), id.end(), id.begin(), ::toupper);
 
 					if (!preproc)
 					{

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2193,6 +2193,8 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::CPlusPlus()
 		
 		langDef.mTokenize = [](const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end, PaletteIndex & paletteIndex) -> bool
 		{
+			paletteIndex = PaletteIndex::Max;
+			
 			while (in_begin < in_end && isblank(*in_begin))
 				in_begin++;
 			
@@ -2201,47 +2203,23 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::CPlusPlus()
 				out_begin = in_end;
 				out_end = in_end;
 				paletteIndex = PaletteIndex::Default;
-				return true;
 			}
 			else if (tokenize_cstyle_comment(in_begin, in_end, out_begin, out_end))
-			{
 				paletteIndex = PaletteIndex::Comment;
-				return true;
-			}
 			else if (tokenize_cstyle_preprocessor_directive(in_begin, in_end, out_begin, out_end))
-			{
 				paletteIndex = PaletteIndex::Preprocessor;
-				return true;
-			}
 			else if (tokenize_cstyle_string(in_begin, in_end, out_begin, out_end))
-			{
 				paletteIndex = PaletteIndex::String;
-				return true;
-			}
 			else if (tokenize_cstyle_character_literal(in_begin, in_end, out_begin, out_end))
-			{
 				paletteIndex = PaletteIndex::CharLiteral;
-				return true;
-			}
 			else if (tokenize_cstyle_identifier(in_begin, in_end, out_begin, out_end))
-			{
 				paletteIndex = PaletteIndex::Identifier;
-				return true;
-			}
 			else if (tokenize_cstyle_number(in_begin, in_end, out_begin, out_end))
-			{
 				paletteIndex = PaletteIndex::Number;
-				return true;
-			}
 			else if (tokenize_cstyle_punctuation(in_begin, in_end, out_begin, out_end))
-			{
 				paletteIndex = PaletteIndex::Punctuation;
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			
+			return paletteIndex != PaletteIndex::Max;
 		};
 		
 		langDef.mCommentStart = "/*";
@@ -2400,17 +2378,37 @@ TextEditor::LanguageDefinition TextEditor::LanguageDefinition::C()
 			langDef.mIdentifiers.insert(std::make_pair(std::string(k), id));
 		}
 
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("//.*", PaletteIndex::Comment));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[ \\t]*#[ \\t]*[a-zA-Z_]+", PaletteIndex::Preprocessor));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("L?\\\"(\\\\.|[^\\\"])*\\\"", PaletteIndex::String));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("\\'\\\\?[^\\']\\'", PaletteIndex::CharLiteral));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?[fF]?", PaletteIndex::Number));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[+-]?[0-9]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[0-7]+[Uu]?[lL]?[lL]?", PaletteIndex::Number));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("0[xX][0-9a-fA-F]+[uU]?[lL]?[lL]?", PaletteIndex::Number));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[a-zA-Z_][a-zA-Z0-9_]*", PaletteIndex::Identifier));
-		langDef.mTokenRegexStrings.push_back(std::make_pair<std::string, PaletteIndex>("[\\[\\]\\{\\}\\!\\%\\^\\&\\*\\(\\)\\-\\+\\=\\~\\|\\<\\>\\?\\/\\;\\,\\.]", PaletteIndex::Punctuation));
-
+		langDef.mTokenize = [](const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end, PaletteIndex & paletteIndex) -> bool
+		{
+			paletteIndex = PaletteIndex::Max;
+			
+			while (in_begin < in_end && isblank(*in_begin))
+				in_begin++;
+			
+			if (in_begin == in_end)
+			{
+				out_begin = in_end;
+				out_end = in_end;
+				paletteIndex = PaletteIndex::Default;
+			}
+			else if (tokenize_cstyle_comment(in_begin, in_end, out_begin, out_end))
+				paletteIndex = PaletteIndex::Comment;
+			else if (tokenize_cstyle_preprocessor_directive(in_begin, in_end, out_begin, out_end))
+				paletteIndex = PaletteIndex::Preprocessor;
+			else if (tokenize_cstyle_string(in_begin, in_end, out_begin, out_end))
+				paletteIndex = PaletteIndex::String;
+			else if (tokenize_cstyle_character_literal(in_begin, in_end, out_begin, out_end))
+				paletteIndex = PaletteIndex::CharLiteral;
+			else if (tokenize_cstyle_identifier(in_begin, in_end, out_begin, out_end))
+				paletteIndex = PaletteIndex::Identifier;
+			else if (tokenize_cstyle_number(in_begin, in_end, out_begin, out_end))
+				paletteIndex = PaletteIndex::Number;
+			else if (tokenize_cstyle_punctuation(in_begin, in_end, out_begin, out_end))
+				paletteIndex = PaletteIndex::Punctuation;
+			
+			return paletteIndex != PaletteIndex::Max;
+		};
+		
 		langDef.mCommentStart = "/*";
 		langDef.mCommentEnd = "*/";
 

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -142,6 +142,7 @@ public:
 	{
 		typedef std::pair<std::string, PaletteIndex> TokenRegexString;
 		typedef std::vector<TokenRegexString> TokenRegexStrings;
+		typedef bool (*TokenizeCallback)(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end, PaletteIndex & paletteIndex);
 
 		std::string mName;
 		Keywords mKeywords;
@@ -149,12 +150,17 @@ public:
 		Identifiers mPreprocIdentifiers;
 		std::string mCommentStart, mCommentEnd;
 		
-		std::function<bool(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end, PaletteIndex & paletteIndex)> mTokenize;
+		TokenizeCallback mTokenize;
 
 		TokenRegexStrings mTokenRegexStrings;
 
 		bool mCaseSensitive;
-
+		
+		LanguageDefinition()
+			: mTokenize(nullptr)
+		{
+		}
+		
 		static const LanguageDefinition& CPlusPlus();
 		static const LanguageDefinition& HLSL();
 		static const LanguageDefinition& GLSL();

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -155,13 +155,13 @@ public:
 
 		bool mCaseSensitive;
 
-		static LanguageDefinition CPlusPlus();
-		static LanguageDefinition HLSL();
-		static LanguageDefinition GLSL();
-		static LanguageDefinition C();
-		static LanguageDefinition SQL();
-		static LanguageDefinition AngelScript();
-		static LanguageDefinition Lua();
+		static const LanguageDefinition& CPlusPlus();
+		static const LanguageDefinition& HLSL();
+		static const LanguageDefinition& GLSL();
+		static const LanguageDefinition& C();
+		static const LanguageDefinition& SQL();
+		static const LanguageDefinition& AngelScript();
+		static const LanguageDefinition& Lua();
 	};
 
 	TextEditor();

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -148,6 +148,8 @@ public:
 		Identifiers mIdentifiers;
 		Identifiers mPreprocIdentifiers;
 		std::string mCommentStart, mCommentEnd;
+		
+		std::function<bool(const char * in_begin, const char * in_end, const char *& out_begin, const char *& out_end, PaletteIndex & paletteIndex)> mTokenize;
 
 		TokenRegexStrings mTokenRegexStrings;
 


### PR DESCRIPTION
Hi,

I've added a code-based approach to colorize (tokenize) the text. I converted the C and C++ language definitions to use this approach. It could easily be ported to Lua and AngelScript etc to optimize syntax highlighting for those languages too.

It works by applying optimized code to detect numbers, string literals and identifiers etc instead of using regular expressions. The time it takes to colorize TextEditor.cpp went down from 178ms to 1ms on my laptop. It's now faster than SetText actually!

When a tokenizer callback is set, it will bump the amount of work to do per frame to 10000 lines instead of 10 and use the tokenizer first instead of regex.

I wonder why the regex approach has to be this slow.. I noticed it's doing _a lot_ of temporary allocations. As far as I could tell (and I tried various approaches) there's no simple solution to this. The C++ runtime is just slow..

Anyway,
Please have a look,
And if you feel like updating the other language definitions, go ahead!

Regards,
Marcel