### PR TITLE
Fix for incorrect undo after 'backspace' at column 0.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1314,7 +1314,7 @@ void TextEditor::BackSpace()
 				return;
 
 			u.mRemoved = '\n';
-			u.mRemovedStart = u.mRemovedEnd = GetActualCursorCoordinates();
+			u.mRemovedStart = u.mRemovedEnd = Coordinates(pos.mLine - 1, (int)mLines[pos.mLine - 1].size());
 			Advance(u.mRemovedEnd);
 
 			auto& line = mLines[mState.mCursorPosition.mLine];


### PR DESCRIPTION
Fix for incorrect undo after 'backspace' at column 0 (concatenating the current line to the previous line). The undo start location should be at the end of the previous line.