### PR TITLE
GetText/SetText optimizes and API improvement.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -825,7 +825,7 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 void TextEditor::SetText(const std::string & aText)
 {
 	mLines.clear();
-	mLines.push_back(Line());
+	mLines.emplace_back(Line());
 	for (auto chr : aText)
 	{
 		if (chr == '\r')
@@ -833,14 +833,43 @@ void TextEditor::SetText(const std::string & aText)
 			// ignore the carriage return character
 		}
 		else if (chr == '\n')
-			mLines.push_back(Line());
+			mLines.emplace_back(Line());
 		else
 		{
-			mLines.back().push_back(Glyph(chr, PaletteIndex::Default));
+			mLines.back().emplace_back(Glyph(chr, PaletteIndex::Default));
 		}
 
 		mTextChanged = true;
 	}
+
+	mUndoBuffer.clear();
+
+	Colorize();
+}
+
+void TextEditor::SetTextLines(const std::vector<std::string> & aLines)
+{
+	mLines.clear();
+	
+	if (aLines.empty())
+	{
+		mLines.emplace_back(Line());
+	}
+	else
+	{
+		mLines.resize(aLines.size());
+		
+		for (size_t i = 0; i < aLines.size(); ++i)
+		{
+			const std::string & aLine = aLines[i];
+			
+			mLines[i].reserve(aLine.size());
+			for (size_t j = 0; j < aLine.size(); ++j)
+				mLines[i].emplace_back(Glyph(aLine[j], PaletteIndex::Default));
+		}
+	}
+
+	mTextChanged = true;
 
 	mUndoBuffer.clear();
 
@@ -1545,6 +1574,27 @@ const TextEditor::Palette & TextEditor::GetRetroBluePalette()
 std::string TextEditor::GetText() const
 {
 	return GetText(Coordinates(), Coordinates((int)mLines.size(), 0));
+}
+
+std::vector<std::string> TextEditor::GetTextLines() const
+{
+	std::vector<std::string> result;
+	
+	result.reserve(mLines.size());
+	
+	for (auto & line : mLines)
+	{
+		std::string text;
+		
+		text.resize(line.size());
+		
+		for (size_t i = 0; i < line.size(); ++i)
+			text[i] = line[i].mChar;
+		
+		result.emplace_back(std::move(text));
+	}
+	
+	return result;
 }
 
 std::string TextEditor::GetSelectedText() const

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -176,7 +176,9 @@ public:
 
 	void Render(const char* aTitle, const ImVec2& aSize = ImVec2(), bool aBorder = false);
 	void SetText(const std::string& aText);
+	void SetTextLines(const std::vector<std::string>& aLines);
 	std::string GetText() const;
+	std::vector<std::string> GetTextLines() const;
 	std::string GetSelectedText() const;
 	std::string GetCurrentLineText()const;
 	


### PR DESCRIPTION
- Small optimizes SetText, GetText.
- Added GetTextLines and SetTextLines, which directly get passed in a vector of strings. The reasons for having these functions are 1) when I save a file, I want to write '\r\n' or '\n' depending on the line ending mode detected when loading a file, or as set by the user through a menu option. In either case, I want to set the line ending myself, instead of having the text editor use '\n' when concatenating all of the lines. 2) when loading a file, I will read the entire file, detect line endings, create strings in a vector. The regular SetText would have my concatenate all of these strings, only so it can split it up again. Passing the vector directly is more than twice as fast and less cumbersome.