### PR TITLE
Added global opacity support by updating palette with alpha from style.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -62,7 +62,7 @@ void TextEditor::SetLanguageDefinition(const LanguageDefinition & aLanguageDef)
 
 void TextEditor::SetPalette(const Palette & aValue)
 {
-	mPalette = aValue;
+	mPaletteBase = aValue;
 }
 
 int TextEditor::AppendBuffer(std::string& aBuffer, char chr, int aIndex)
@@ -614,6 +614,14 @@ void TextEditor::Render()
 	const float fontSize = ImGui::CalcTextSize("#").x;
 	mCharAdvance = ImVec2(fontSize, ImGui::GetTextLineHeightWithSpacing() * mLineSpacing);
 
+	/* Update palette with the current alpha from style */
+	for (int i = 0; i < (int)PaletteIndex::Max; ++i)
+	{
+		auto color = ImGui::ColorConvertU32ToFloat4(mPaletteBase[i]);
+		color.w *= ImGui::GetStyle().Alpha;
+		mPalette[i] = ImGui::ColorConvertFloat4ToU32(color);
+	}
+	
 	static std::string buffer;
 	auto contentSize = ImGui::GetWindowContentRegionMax();
 	auto drawList = ImGui::GetWindowDrawList();

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -181,7 +181,7 @@ public:
 	void SetLanguageDefinition(const LanguageDefinition& aLanguageDef);
 	const LanguageDefinition& GetLanguageDefinition() const { return mLanguageDefinition; }
 
-	const Palette& GetPalette() const { return mPalette; }
+	const Palette& GetPalette() const { return mPaletteBase; }
 	void SetPalette(const Palette& aValue);
 
 	void SetErrorMarkers(const ErrorMarkers& aMarkers) { mErrorMarkers = aMarkers; }
@@ -335,6 +335,7 @@ private:
 	int mColorRangeMin, mColorRangeMax;
 	SelectionMode mSelectionMode;
 
+	Palette mPaletteBase;
 	Palette mPalette;
 	LanguageDefinition mLanguageDefinition;
 	RegexList mRegexList;


### PR DESCRIPTION
Hi,

I added support for the global alpha setting from the current style. This allows the UI to fade in and out correctly. I made the changes against master, since dev doesn't include some of the major refactoring that went on in master.

Before, no correct alpha fade, https://youtu.be/d336IKGGZoE.
After, with alpha fade, https://youtu.be/OMsHiAKtu1Y

Cheers,
Marcel