### PR TITLE
Fix for not resetting the scroll position back to the top when SetText or SetTextLines is called.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -34,6 +34,7 @@ TextEditor::TextEditor()
 	, mReadOnly(false)
 	, mWithinRender(false)
 	, mScrollToCursor(false)
+	, mScrollToTop(false)
 	, mTextChanged(false)
 	, mTextStart(20.0f)
 	, mLeftMargin(10)
@@ -618,6 +619,12 @@ void TextEditor::Render()
 	auto contentSize = ImGui::GetWindowContentRegionMax();
 	auto drawList = ImGui::GetWindowDrawList();
 	float longest(mTextStart);
+	
+	if (mScrollToTop)
+	{
+		mScrollToTop = false;
+		ImGui::SetScrollY(0.f);
+	}
 
 	ImVec2 cursorScreenPos = ImGui::GetCursorScreenPos();
 	auto scrollX = ImGui::GetScrollX();
@@ -847,9 +854,10 @@ void TextEditor::SetText(const std::string & aText)
 		{
 			mLines.back().emplace_back(Glyph(chr, PaletteIndex::Default));
 		}
-
-		mTextChanged = true;
 	}
+	
+	mTextChanged = true;
+	mScrollToTop = true;
 
 	mUndoBuffer.clear();
 
@@ -879,6 +887,7 @@ void TextEditor::SetTextLines(const std::vector<std::string> & aLines)
 	}
 
 	mTextChanged = true;
+	mScrollToTop = true;
 
 	mUndoBuffer.clear();
 

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -328,6 +328,7 @@ private:
 	bool mReadOnly;
 	bool mWithinRender;
 	bool mScrollToCursor;
+	bool mScrollToTop;
 	bool mTextChanged;
 	float  mTextStart;                   // position (in pixels) where a code line starts relative to the left of the TextEditor.
 	int  mLeftMargin;


### PR DESCRIPTION
This causes the scroll position to remain where it is when for instance loading another file from disk. Expected behavior would be to scroll back to the top, instead of presenting the new file somewhere in the middle (or, quite often, at the end).