### PR TITLE
Fix for crash which can happen if unindent operation (shift + TAB) is…

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -921,19 +921,25 @@ void TextEditor::EnterCharacter(Char aChar, bool aShift)
 				auto& line = mLines[i];
 				if (aShift)
 				{
-					if (line[0].mChar == '\t')
+					if (line.empty() == false)
 					{
-						line.erase(line.begin());
-						if (i == end.mLine && end.mColumn > 0)
-							end.mColumn--;
-						modified = true;
+						if (line.front().mChar == '\t')
+						{
+							line.erase(line.begin());
+							if (i == end.mLine && end.mColumn > 0)
+								end.mColumn--;
+							modified = true;
+						}
 					}
-					else for (int j = 0; j < mTabSize && line[0].mChar == ' '; j++)
+					else
 					{
-						line.erase(line.begin());
-						if (i == end.mLine && end.mColumn > 0)
-							end.mColumn--;
-						modified = true;
+						for (int j = 0; j < mTabSize && line.empty() == false && line.front().mChar == ' '; j++)
+						{
+							line.erase(line.begin());
+							if (i == end.mLine && end.mColumn > 0)
+								end.mColumn--;
+							modified = true;
+						}
 					}
 				}
 				else


### PR DESCRIPTION
… performed on a (selection of) line(s) which are empty.