### PR TITLE
Triple click fix

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -41,6 +41,7 @@ TextEditor::TextEditor()
 	, mColorRangeMax(0)
 	, mSelectionMode(SelectionMode::Normal)
 	, mCheckComments(true)
+	, mLastClick(-1.0f)
 {
 	SetPalette(GetDarkPalette());
 	SetLanguageDefinition(LanguageDefinition::HLSL());
@@ -540,13 +541,12 @@ void TextEditor::HandleMouseInputs()
 
 	if (ImGui::IsWindowHovered())
 	{
-		static float lastClick = -1.0f;
 		if (!shift && !alt)
 		{
 			auto click = ImGui::IsMouseClicked(0);
 			auto doubleClick = ImGui::IsMouseDoubleClicked(0);
 			auto t = ImGui::GetTime();
-			auto tripleClick = click && !doubleClick && t - lastClick < io.MouseDoubleClickTime;
+			auto tripleClick = click && !doubleClick && (mLastClick != -1.0f && (t - mLastClick) < io.MouseDoubleClickTime);
 
 			/*
 				Left mouse button triple click
@@ -561,7 +561,7 @@ void TextEditor::HandleMouseInputs()
 					SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
 				}
 
-				lastClick = -1.0f;
+				mLastClick = -1.0f;
 			}
 
 			/*
@@ -580,7 +580,7 @@ void TextEditor::HandleMouseInputs()
 					SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
 				}
 
-				lastClick = (float)ImGui::GetTime();
+				mLastClick = (float)ImGui::GetTime();
 			}
 
 			/*
@@ -595,7 +595,7 @@ void TextEditor::HandleMouseInputs()
 					mSelectionMode = SelectionMode::Normal;
 				SetSelection(mInteractiveStart, mInteractiveEnd, mSelectionMode);
 
-				lastClick = (float)ImGui::GetTime();
+				mLastClick = (float)ImGui::GetTime();
 			}
 			// Mouse left button dragging (=> update selection)
 			else if (ImGui::IsMouseDragging(0) && ImGui::IsMouseDown(0))

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -344,4 +344,6 @@ private:
 	ErrorMarkers mErrorMarkers;
 	ImVec2 mCharAdvance;
 	Coordinates mInteractiveStart, mInteractiveEnd;
+	
+	float mLastClick;
 };


### PR DESCRIPTION
Fix for triple click glitch when using multiple text editors or when destroying/creating instances due to the use of a static variable to track triple click time.