### PR TITLE
Fix Lua syntax highlighting.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2718,6 +2718,7 @@ const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::Lua()
 
 		langDef.mCommentStart = "--[[";
 		langDef.mCommentEnd = "]]";
+		langDef.mSingleLineComment = "--";
 
 		langDef.mCaseSensitive = true;
 		langDef.mAutoIndentation = false;


### PR DESCRIPTION
Not defining langDef.mSingleLineComment was causing the entirety
of a Lua program to be seen as a comment.