### PR TITLE
Fix single line comment logic.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1924,7 +1924,8 @@ void TextEditor::ColorizeInternal()
 						auto from = line.begin() + currentCoord.mColumn;
 						auto& startStr = mLanguageDefinition.mCommentStart;
 						auto& singleStartStr = mLanguageDefinition.mSingleLineComment;
-						if (currentCoord.mColumn + singleStartStr.size() <= line.size() &&
+						if (singleStartStr.size() > 0 &&
+							currentCoord.mColumn + singleStartStr.size() <= line.size() &&
 							equals(singleStartStr.begin(), singleStartStr.end(), from, from + singleStartStr.size(), pred))
 							withinSingleLineComment = true;
 						else if (!withinSingleLineComment && currentCoord.mColumn + startStr.size() <= line.size() &&


### PR DESCRIPTION
It seems reasonable to check that langDef.mSingleLineComment is
non-empty before trying to match it with the current line of code.