### PR TITLE
input using 'alt gr' not working on linux

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -518,7 +518,7 @@ void TextEditor::HandleKeyboardInputs()
 			EnterCharacter('\n', false);
 		else if (!IsReadOnly() && !ctrl && !alt && ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Tab)))
 			EnterCharacter('\t', shift);
-		else if (!IsReadOnly() && !ctrl && !alt)
+		else if (!IsReadOnly() && !ctrl)
 		{
 			for (int i = 0; i < io.InputQueueCharacters.Size; i++)
 			{


### PR DESCRIPTION
on german keyborads you need alt gr for some essential chars ('{', '[', etc..).
(maybe related: ocornut/imgui#334)

i couldn't find a better solution :/

edit: imgui is doing the same (https://github.com/ocornut/imgui/blob/0a1d6b6b74023039e3ec71ad8ad593fedc9cac83/imgui.cpp#L7180)