### PR TITLE
Fix last unnecessary linefeed at the end of the GetText returning string

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -104,7 +104,9 @@ std::string TextEditor::GetText(const Coordinates & aStart, const Coordinates & 
 		{
 			istart = 0;
 			++lstart;
-			result += '\n';
+
+			if (lstart < lend)
+				result += '\n';
 		}
 	}
 


### PR DESCRIPTION
When using the GetText method, the resulting string has a new linefeed at the last line that the original string didn't have. This is noticeable when saving a string to a file, because the resulting script has a new linefeed each time the file is saved.