### PR TITLE
Fix cursor position deleting a tab character

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1870,7 +1870,11 @@ void TextEditor::Backspace()
 
 			u.mRemovedStart = u.mRemovedEnd = GetActualCursorCoordinates();
 			--u.mRemovedStart.mColumn;
-			--mState.mCursorPosition.mColumn;
+
+			if (line[cindex].mChar == '\t')
+				mState.mCursorPosition.mColumn -= mTabSize;
+			else
+				--mState.mCursorPosition.mColumn;
 
 			while (cindex < line.size() && cend-- > cindex)
 			{


### PR DESCRIPTION
When deleting a tab character this happens:

![bug](https://user-images.githubusercontent.com/23530586/59984169-7b6ad280-9627-11e9-9ab0-02ace4a0d37b.gif)

This pr fixes that.