### PR TITLE
Fix cursor when pasting text with tabs

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -298,14 +298,8 @@ int TextEditor::InsertTextAt(Coordinates& /* inout */ aWhere, const char * aValu
 			auto& line = mLines[aWhere.mLine];
 			auto d = UTF8CharLength(*aValue);
 			while (d-- > 0 && *aValue != '\0')
-				line.insert(line.begin() + cindex++, Glyph(*aValue, PaletteIndex::Default));
-
-			if (*aValue == '\t')
-				aWhere.mColumn += mTabSize;
-			else
-				++aWhere.mColumn;
-
-			++aValue;
+				line.insert(line.begin() + cindex++, Glyph(*aValue++, PaletteIndex::Default));
+			aWhere.mColumn = GetCharacterColumn(aWhere.mLine, cindex);
 		}
 
 		mTextChanged = true;

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -298,8 +298,14 @@ int TextEditor::InsertTextAt(Coordinates& /* inout */ aWhere, const char * aValu
 			auto& line = mLines[aWhere.mLine];
 			auto d = UTF8CharLength(*aValue);
 			while (d-- > 0 && *aValue != '\0')
-				line.insert(line.begin() + cindex++, Glyph(*aValue++, PaletteIndex::Default));
-			++aWhere.mColumn;
+				line.insert(line.begin() + cindex++, Glyph(*aValue, PaletteIndex::Default));
+
+			if (*aValue == '\t')
+				aWhere.mColumn += mTabSize;
+			else
+				++aWhere.mColumn;
+
+			++aValue;
 		}
 
 		mTextChanged = true;


### PR DESCRIPTION
When pasting text with tab characters this happens:

![tab cursor bug](https://user-images.githubusercontent.com/23530586/60722019-f2f60700-9f2f-11e9-963c-2cb9fb9f1bf4.gif)
