### PR TITLE
Decreased tab symbol size to improve look

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -47,6 +47,7 @@ TextEditor::TextEditor()
 	, mHandleMouseInputs(true)
 	, mIgnoreImGuiChild(false)
 	, mShowWhitespaces(true)
+	, mShowShortTabGlyphs(false)
 	, mStartTime(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count())
 {
 	SetPalette(GetDarkPalette());
@@ -1038,14 +1039,33 @@ void TextEditor::Render()
 
 					if (mShowWhitespaces)
 					{
-						const auto s = ImGui::GetFontSize();
-						const auto x1 = textScreenPos.x + oldX + 1.0f;
-						const auto x2 = textScreenPos.x + oldX + mCharAdvance.x - 1.0f;
-						const auto y = textScreenPos.y + bufferOffset.y + s * 0.5f;
-						const ImVec2 p1(x1, y);
-						const ImVec2 p2(x2, y);
-						const ImVec2 p3(x2 - s * 0.16f, y - s * 0.16f);
-						const ImVec2 p4(x2 - s * 0.16f, y + s * 0.16f);
+						ImVec2 p1, p2, p3, p4;
+
+						if (mShowShortTabGlyphs)
+						{
+							const auto s = ImGui::GetFontSize();
+							const auto x1 = textScreenPos.x + oldX + 1.0f;
+							const auto x2 = textScreenPos.x + oldX + mCharAdvance.x - 1.0f;
+							const auto y = textScreenPos.y + bufferOffset.y + s * 0.5f;
+
+							p1 = ImVec2(x1, y);
+							p2 = ImVec2(x2, y);
+							p3 = ImVec2(x2 - s * 0.16f, y - s * 0.16f);
+							p4 = ImVec2(x2 - s * 0.16f, y + s * 0.16f);
+						}
+						else
+						{
+							const auto s = ImGui::GetFontSize();
+							const auto x1 = textScreenPos.x + oldX + 1.0f;
+							const auto x2 = textScreenPos.x + bufferOffset.x - 1.0f;
+							const auto y = textScreenPos.y + bufferOffset.y + s * 0.5f;
+
+							p1 = ImVec2(x1, y);
+							p2 = ImVec2(x2, y);
+							p3 = ImVec2(x2 - s * 0.2f, y - s * 0.2f);
+							p4 = ImVec2(x2 - s * 0.2f, y + s * 0.2f);
+						}
+
 						drawList->AddLine(p1, p2, 0x90909090);
 						drawList->AddLine(p2, p3, 0x90909090);
 						drawList->AddLine(p2, p4, 0x90909090);

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1040,12 +1040,12 @@ void TextEditor::Render()
 					{
 						const auto s = ImGui::GetFontSize();
 						const auto x1 = textScreenPos.x + oldX + 1.0f;
-						const auto x2 = textScreenPos.x + bufferOffset.x - 1.0f;
+						const auto x2 = textScreenPos.x + oldX + mCharAdvance.x - 1.0f;
 						const auto y = textScreenPos.y + bufferOffset.y + s * 0.5f;
 						const ImVec2 p1(x1, y);
 						const ImVec2 p2(x2, y);
-						const ImVec2 p3(x2 - s * 0.2f, y - s * 0.2f);
-						const ImVec2 p4(x2 - s * 0.2f, y + s * 0.2f);
+						const ImVec2 p3(x2 - s * 0.16f, y - s * 0.16f);
+						const ImVec2 p4(x2 - s * 0.16f, y + s * 0.16f);
 						drawList->AddLine(p1, p2, 0x90909090);
 						drawList->AddLine(p2, p3, 0x90909090);
 						drawList->AddLine(p2, p4, 0x90909090);

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -230,6 +230,9 @@ public:
 	inline void SetShowWhitespaces(bool aValue) { mShowWhitespaces = aValue; }
 	inline bool IsShowingWhitespaces() const { return mShowWhitespaces; }
 
+	inline void SetShowShortTabGlyphs(bool aValue) { mShowShortTabGlyphs = aValue; }
+	inline bool IsShowingShortTabGlyphs() const { return mShowShortTabGlyphs; }
+
 	void SetTabSize(int aValue);
 	inline int GetTabSize() const { return mTabSize; }
 
@@ -371,6 +374,7 @@ private:
 	bool mHandleMouseInputs;
 	bool mIgnoreImGuiChild;
 	bool mShowWhitespaces;
+	bool mShowShortTabGlyphs;
 
 	Palette mPaletteBase;
 	Palette mPalette;


### PR DESCRIPTION
I think that the tab symbol is really large and this decreases the general clarity of the code when there are lots of tab characters. This is how it looks currently:

<img width="307" alt="image" src="https://user-images.githubusercontent.com/23530586/60724444-bda0e780-9f36-11e9-8097-6cf25be1657f.png">


This is the proposed look (similar to Visual Studio Code):

<img width="303" alt="image" src="https://user-images.githubusercontent.com/23530586/60725903-83394980-9f3a-11e9-9d31-b7b253448dd4.png">

