### PR TITLE
Fast syntax highlighting for Lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The code is (still) work in progress, please report if you find any issues.
  - color palette support: you can switch between different color palettes, or even define your own
  
 # Known issues
- - syntax highligthing of most languages - except C/C++ - is based on std::regex, which is diasppointingly slow. Because of that, the highlighting process is amortized between multiple frames. C/C++ has a hand-written tokenizer which is much faster. 
+ - syntax highligthing of most languages - except C/C++ and Lua - is based on std::regex, which is diasppointingly slow. Because of that, the highlighting process is amortized between multiple frames. C/C++ and Lua have a hand-written tokenizer which is much faster. 
  
 Please post your screenshots if you find this little piece of software useful. :)
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2335,17 +2335,17 @@ void TextEditor::ColorizeInternal()
 						auto& startStr = mLanguageDefinition.mCommentStart;
 						auto& singleStartStr = mLanguageDefinition.mSingleLineComment;
 
-						if (singleStartStr.size() > 0 &&
-							currentIndex + singleStartStr.size() <= line.size() &&
-							equals(singleStartStr.begin(), singleStartStr.end(), from, from + singleStartStr.size(), pred))
-						{
-							withinSingleLineComment = true;
-						}
-						else if (!withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
+						if (!withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
 							equals(startStr.begin(), startStr.end(), from, from + startStr.size(), pred))
 						{
 							commentStartLine = currentLine;
 							commentStartIndex = currentIndex;
+						}
+						else if (singleStartStr.size() > 0 &&
+							currentIndex + singleStartStr.size() <= line.size() &&
+							equals(singleStartStr.begin(), singleStartStr.end(), from, from + singleStartStr.size(), pred))
+						{
+							withinSingleLineComment = true;
 						}
 
 						inComment = inComment = (commentStartLine < currentLine || (commentStartLine == currentLine && commentStartIndex <= currentIndex));

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2758,7 +2758,8 @@ static bool TokenizeLuaStyleString(const char * in_begin, const char * in_end, c
 		is_double_quotes = true;
 		break;
 	case '[':
-		if (*(p + 1) == '[')
+		p++;
+		if (p < in_end && *(p) == '[')
 			is_double_square_brackets = true;
 		break;
 	}
@@ -2770,7 +2771,7 @@ static bool TokenizeLuaStyleString(const char * in_begin, const char * in_end, c
 		while (p < in_end)
 		{
 			// handle end of string
-			if ((is_single_quote && *p == '\'') || (is_double_quotes && *p == '"') || (is_double_square_brackets && *p == ']' && *(p + 1) == ']'))
+			if ((is_single_quote && *p == '\'') || (is_double_quotes && *p == '"') || (is_double_square_brackets && *p == ']' && p + 1 < in_end && *(p + 1) == ']'))
 			{
 				out_begin = in_begin;
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -3289,7 +3289,7 @@ const TextEditor::LanguageDefinition& TextEditor::LanguageDefinition::Lua()
 	if (!inited)
 	{
 		static const char* const keywords[] = {
-			"and", "break", "do", "", "else", "elseif", "end", "false", "for", "function", "if", "in", "", "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while"
+			"and", "break", "do", "else", "elseif", "end", "false", "for", "function", "goto", "if", "in", "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while"
 		};
 
 		for (auto& k : keywords)


### PR DESCRIPTION
Following #44 I have adapted the new hand-written tokenizer to Lua.

This PR also partially fixes [this](https://github.com/BalazsJako/ImGuiColorTextEdit/issues/47) issue (I have not yet implemented the fix for multi-line comments):

Before
![image](https://user-images.githubusercontent.com/23530586/60736762-6dd31800-9f58-11e9-8e1e-37752a6c488c.png)

After 
![image](https://user-images.githubusercontent.com/23530586/60736752-63b11980-9f58-11e9-84b9-5c238366601c.png)

As written in the screenshots the only missing part for strings is the nested quotes with square brackets and equals ([here](http://lua-users.org/wiki/StringsTutorial) for more informations), but this is relatively intricate to implement and I think it's not even super used, so maybe it can be implemented later.

As I said, the only missing part that I want to implement before merging is the fix for [multi-line comments](https://github.com/BalazsJako/ImGuiColorTextEdit/issues/94).

EDIT:
I have now fixed the multi-line comments bug and I have also added the missing goto keyword, so now I think that this PR can be merged.