### PR TITLE
Proposal : First version of an ExternalUndoBufferInterface

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1482,12 +1482,12 @@ void TextEditor::SetTabSize(int aValue)
 	mTabSize = std::max(0, std::min(32, aValue));
 }
 
-void TextEditor::InsertText(const std::string & aValue)
+void TextEditor::InsertText(const std::string & aValue, bool aSelect)
 {
-	InsertText(aValue.c_str());
+	InsertText(aValue.c_str(), aSelect);
 }
 
-void TextEditor::InsertText(const char * aValue)
+void TextEditor::InsertText(const char * aValue, bool aSelect)
 {
 	if (aValue == nullptr)
 		return;
@@ -1514,7 +1514,7 @@ void TextEditor::InsertText(const char * aValue)
 
 	totalLines += InsertTextAt(pos, aValue);
 
-	SetSelection(pos, pos);
+	SetSelection( std::min(u.mBefore.mSelectionStart, u.mBefore.mCursorPosition) , pos);
 	SetCursorPosition(pos);
 	Colorize(start.mLine - 1, totalLines + 2);
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1429,6 +1429,16 @@ void TextEditor::SetSelectionEnd(const Coordinates & aPosition)
 		std::swap(mState.mSelectionStart, mState.mSelectionEnd);
 }
 
+const TextEditor::Coordinates TextEditor::GetSelectionStart() const
+{
+	return mState.mSelectionStart;
+}
+
+const TextEditor::Coordinates TextEditor::GetSelectionEnd() const
+{
+	return mState.mSelectionEnd;
+}
+
 void TextEditor::SetSelection(const Coordinates & aStart, const Coordinates & aEnd, SelectionMode aMode)
 {
 	auto oldSelStart = mState.mSelectionStart;
@@ -1938,6 +1948,7 @@ bool TextEditor::HasSelection() const
 {
 	return mState.mSelectionEnd > mState.mSelectionStart;
 }
+
 
 void TextEditor::Copy()
 {

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -323,7 +323,7 @@ void TextEditor::AddUndo(UndoRecord& aValue)
 
 	// If a custom undo buffer is set we send the undo value on it
 	if ( mExternalUndoBuffer != nullptr) {
-		mExternalUndoBuffer->AddUndo(aValue, *this);
+		mExternalUndoBuffer->AddUndo(aValue);
 	}
 }
 

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -283,8 +283,8 @@ public:
 	void SetTabSize(int aValue);
 	inline int GetTabSize() const { return mTabSize; }
 
-	void InsertText(const std::string& aValue);
-	void InsertText(const char* aValue);
+	void InsertText(const std::string& aValue, bool aSelect = false);
+	void InsertText(const char* aValue, bool aSelect = false);
 
 	void MoveUp(int aAmount = 1, bool aSelect = false);
 	void MoveDown(int aAmount = 1, bool aSelect = false);

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -227,11 +227,7 @@ public:
 	class ExternalUndoBufferInterface
 	{
 	public:
-		ExternalUndoBufferInterface() {};
-		~ExternalUndoBufferInterface() {};
-
-		virtual void AddUndo(UndoRecord&, TextEditor&)=0;
-
+		virtual void AddUndo(UndoRecord&) = 0;
 	};
 
 	typedef std::vector<UndoRecord> UndoBuffer;

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -297,6 +297,8 @@ public:
 
 	void SetSelectionStart(const Coordinates& aPosition);
 	void SetSelectionEnd(const Coordinates& aPosition);
+	const Coordinates GetSelectionStart()const;
+	const Coordinates GetSelectionEnd()const;
 	void SetSelection(const Coordinates& aStart, const Coordinates& aEnd, SelectionMode aMode = SelectionMode::Normal);
 	void SelectWordUnderCursor();
 	void SelectAll();


### PR DESCRIPTION
Hello,

First draft version of an external undo buffer interface.

The concept is simple, this interface consists on a single method that can receive an UndoRecord& as ar gument. This method is called only if the TextEditor as an mExternalUndoRecordBuffer not null.

I had to set public a lot of your classes: UndoRecord, EditorState and the type UndoBuffer.

I choose to modify as less possible things, but I think it should be better to introduce a boolean to says is undobuffer is internal or external and then use that boolean to avoid all internal undo/redo stuff.

I don't really know why UndoRecord.Undo() takes a TextEditor pointer. Is is to avoid to store it in each Record ?

Let me know your impressions about my proposal.

Cheers