### PR TITLE
Issue with tooltip when first line/column

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -6,7 +6,9 @@
 
 #include "TextEditor.h"
 
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "imgui.h" // for imGui::GetCurrentWindow()
 
 #ifndef isascii

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1085,7 +1085,7 @@ void TextEditor::Render()
 		}
 
 		// Draw a tooltip on known identifiers/preprocessor symbols
-		if (ImGui::IsMousePosValid())
+		if (ImGui::IsMousePosValid() && ImGui::IsWindowHovered())
 		{
 			auto id = GetWordAt(ScreenPosToCoordinates(ImGui::GetMousePos()));
 			if (!id.empty())

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -9,6 +9,10 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include "imgui.h" // for imGui::GetCurrentWindow()
 
+#ifndef isascii
+#define isascii(a) ((unsigned)(a) < 128)
+#endif
+
 // TODO
 // - multiline comments vs single-line: latter is blocking start of a ML
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1138,7 +1138,8 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 	if (mHandleKeyboardInputs)
 	{
 		HandleKeyboardInputs();
-		ImGui::PushAllowKeyboardFocus(true);
+		// tofix
+		//ImGui::PushAllowKeyboardFocus(true);
 	}
 
 	if (mHandleMouseInputs)
@@ -1147,8 +1148,9 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 	ColorizeInternal();
 	Render();
 
-	if (mHandleKeyboardInputs)
-		ImGui::PopAllowKeyboardFocus();
+	// tofix
+	//if (mHandleKeyboardInputs)
+	//	ImGui::PopAllowKeyboardFocus();
 
 	if (!mIgnoreImGuiChild)
 		ImGui::EndChild();


### PR DESCRIPTION
Hello,

thanks for your great lib :)

i have an issue when a tooltip must be displayed on a word who is on first line or first column

![FbpvjJccNv](https://user-images.githubusercontent.com/1434736/93686112-6c860080-fab4-11ea-9ce0-19920737cd84.gif)


also has an issue on some system with the func isasscii

so i propose a PR after solved these thow things. :)

thanks :)