### PR TITLE
Multi-Line comments are incorrectly detected as the entire file

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2335,7 +2335,7 @@ void TextEditor::ColorizeInternal()
 						{
 							withinSingleLineComment = true;
 						}
-						else if (!withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
+						else if (startStr.size() != 0 && !withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
 							equals(startStr.begin(), startStr.end(), from, from + startStr.size(), pred))
 						{
 							commentStartLine = currentLine;


### PR DESCRIPTION
If LanguageDefinition.mSingleLineComment is left blank, then all lines are detected as being a comment. This PR fixes this issue.