### PR TITLE
Fix a bug where multiline comments weren't being highlighted if the beginning of the multiline comment contained the same characters as a single line comment

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2331,7 +2331,8 @@ void TextEditor::ColorizeInternal()
 
 						if (singleStartStr.size() > 0 &&
 							currentIndex + singleStartStr.size() <= line.size() &&
-							equals(singleStartStr.begin(), singleStartStr.end(), from, from + singleStartStr.size(), pred))
+							equals(singleStartStr.begin(), singleStartStr.end(), from, from + singleStartStr.size(), pred) &&
+							!equals(startStr.begin(), startStr.end(), from, from + startStr.size(), pred))
 						{
 							withinSingleLineComment = true;
 						}

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2331,12 +2331,18 @@ void TextEditor::ColorizeInternal()
 
 						if (singleStartStr.size() > 0 &&
 							currentIndex + singleStartStr.size() <= line.size() &&
-							equals(singleStartStr.begin(), singleStartStr.end(), from, from + singleStartStr.size(), pred) &&
-							!equals(startStr.begin(), startStr.end(), from, from + startStr.size(), pred))
+							equals(singleStartStr.begin(), singleStartStr.end(), from, from + singleStartStr.size(), pred))
 						{
-							withinSingleLineComment = true;
+							if (currentIndex + startStr.size() > line.size())
+							{
+								withinSingleLineComment = true;
+							}
+							else if (!equals(startStr.begin(), startStr.end(), from, from + startStr.size(), pred))
+							{
+								withinSingleLineComment = true;
+							}
 						}
-						else if (!withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
+						if (!withinSingleLineComment && currentIndex + startStr.size() <= line.size() &&
 							equals(startStr.begin(), startStr.end(), from, from + startStr.size(), pred))
 						{
 							commentStartLine = currentLine;


### PR DESCRIPTION
This specifically effects Lua:

```lua
-- This is a single line comment. It's handled fine.

--[[ This is a multi-line comment.
Because of the bug, only the first line
is highlighted as a comment currently.]]
```