### PR TITLE
Added IMGUI export specification

### DIFF
--- a/TextEditor.h
+++ b/TextEditor.h
@@ -10,7 +10,7 @@
 #include <regex>
 #include "imgui.h"
 
-class TextEditor
+class IMGUI_API TextEditor
 {
 public:
 	enum class PaletteIndex


### PR DESCRIPTION
ImGui defines an export specification (IMGUI_API) that is declared in imconfig.h and referenced in the ImGui source so classes and functions can be exported / imported if needed. This is missing from (the excellent) TextEditor so have added if (like me) you rely on ImGui's export / import specs.