### PR TITLE
fix: Remove redundant assignment

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2389,7 +2389,7 @@ void TextEditor::ColorizeInternal()
 							withinSingleLineComment = true;
 						}
 
-						inComment = inComment = (commentStartLine < currentLine || (commentStartLine == currentLine && commentStartIndex <= currentIndex));
+						inComment = (commentStartLine < currentLine || (commentStartLine == currentLine && commentStartIndex <= currentIndex));
 
 						line[currentIndex].mMultiLineComment = inComment;
 						line[currentIndex].mComment = withinSingleLineComment;


### PR DESCRIPTION
This caused gcc to emit a 'operation on ‘inComment’ may be undefined
[-Wsequence-point]' warning.