### PR TITLE
Fix scrolling issue

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1107,7 +1107,7 @@ void TextEditor::Render()
 		}
 	}
 
-
+	ImGui::SetCursorPos(ImVec2(0, 0));
 	ImGui::Dummy(ImVec2((longest + 2), mLines.size() * mCharAdvance.y));
 
 	if (mScrollToCursor)


### PR DESCRIPTION
While I'm not able to determine if it always happens, in my use case, the scroll bar was much bigger than it needed to be. That meant it could scroll past the text. When the text fully disappeared from my screen, it'd automatically scroll way up, making it jitter and really annoying to work with.

The fix was as simple as resetting the cursor to (0, 0) (local space) before creating a dummy.