### PR TITLE
Remove usages of obsolete ImGui functions

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1161,7 +1161,7 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 	if (mHandleKeyboardInputs)
 	{
 		HandleKeyboardInputs();
-		ImGui::PushAllowKeyboardFocus(true);
+		ImGui::PushTabStop(true);
 	}
 
 	if (mHandleMouseInputs)
@@ -1171,7 +1171,7 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
 	Render();
 
 	if (mHandleKeyboardInputs)
-		ImGui::PopAllowKeyboardFocus();
+		ImGui::PopTabStop();
 
 	if (!mIgnoreImGuiChild)
 		ImGui::EndChild();


### PR DESCRIPTION
Remove usages of `ImGui::PushAllowKeyboardFocus` and `ImGui::PopAllowKeyboardFocus`

(Obsolete since ImGui 1.89.4 (March 2023))