### PR TITLE
Add `TextEditor::IsSaved(...)`

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1985,6 +1985,14 @@ bool TextEditor::CanUndo() const
 {
 	return !mReadOnly && mUndoIndex > 0;
 }
+int TextEditor::GetUndoIndex() const
+{
+	return mUndoIndex;
+}
+size_t TextEditor::GetUndoBufferSize() const
+{
+	return mUndoBuffer.size();
+}
 
 bool TextEditor::CanRedo() const
 {

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -52,6 +52,8 @@ TextEditor::TextEditor()
 	SetPalette(GetDarkPalette());
 	SetLanguageDefinition(LanguageDefinition::HLSL());
 	mLines.push_back(Line());
+	
+	MarkSaved();
 }
 
 TextEditor::~TextEditor()
@@ -318,7 +320,13 @@ void TextEditor::AddUndo(UndoRecord& aValue)
 
 	mUndoBuffer.resize((size_t)(mUndoIndex + 1));
 	mUndoBuffer.back() = aValue;
+
+	if(mUndoIndex < mUndoIndexFirstEdit)
+		mUndoIndexFirstEdit = mUndoIndex;
+
 	++mUndoIndex;
+
+	mSaveState = false;
 }
 
 TextEditor::Coordinates TextEditor::ScreenPosToCoordinates(const ImVec2& aPosition) const
@@ -1172,6 +1180,7 @@ void TextEditor::SetText(const std::string & aText)
 	}
 
 	mTextChanged = true;
+	MarkSaved();
 	mScrollToTop = true;
 
 	mUndoBuffer.clear();
@@ -1203,6 +1212,7 @@ void TextEditor::SetTextLines(const std::vector<std::string> & aLines)
 	}
 
 	mTextChanged = true;
+	MarkSaved();
 	mScrollToTop = true;
 
 	mUndoBuffer.clear();
@@ -2003,12 +2013,52 @@ void TextEditor::Undo(int aSteps)
 {
 	while (CanUndo() && aSteps-- > 0)
 		mUndoBuffer[--mUndoIndex].Undo(this);
+
+	if(mUndoIndex == mUndoIndexLastSave){
+		if(mUndoIndexFirstEdit >= mUndoIndexLastSave && !mMarkedUnsaved)
+			mSaveState = true;
+	} else
+		mSaveState = false;
 }
 
 void TextEditor::Redo(int aSteps)
 {
 	while (CanRedo() && aSteps-- > 0)
 		mUndoBuffer[mUndoIndex++].Redo(this);
+
+	if(mUndoIndex == mUndoIndexLastSave){
+		if(mUndoIndexFirstEdit >= mUndoIndexLastSave && !mMarkedUnsaved)
+			mSaveState = true;
+	} else
+		mSaveState = false;
+}
+
+void TextEditor::MarkSaved()
+{
+	mSaveState = true;
+	mMarkedUnsaved = false;
+	mUndoIndexLastSave = mUndoIndex;
+	mUndoIndexFirstEdit = mUndoIndex;
+}
+
+// Marks the file changed in a way that can't be reverted with undo/redo
+void TextEditor::MarkUnsaved()
+{
+	mSaveState = false;
+	mMarkedUnsaved = true;
+}
+void TextEditor::MarkSaved(bool saveState)
+{
+	if(saveState){
+		mUndoIndexLastSave = mUndoIndex;
+		mUndoIndexFirstEdit = mUndoIndex;
+	} else
+		mMarkedUnsaved = true;
+	mSaveState = saveState;
+	mMarkedUnsaved = !saveState;
+}
+bool TextEditor::IsSaved() const{
+	return mSaveState;
 }
 
 const TextEditor::Palette & TextEditor::GetDarkPalette()

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -262,6 +262,9 @@ public:
 	void Undo(int aSteps = 1);
 	void Redo(int aSteps = 1);
 
+	int GetUndoIndex() const;
+	size_t GetUndoBufferSize() const;
+
 	static const Palette& GetDarkPalette();
 	static const Palette& GetLightPalette();
 	static const Palette& GetRetroBluePalette();

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -265,6 +265,11 @@ public:
 	int GetUndoIndex() const;
 	size_t GetUndoBufferSize() const;
 
+	void MarkSaved();
+	void MarkUnsaved();
+	void MarkSaved(bool saveState);
+	bool IsSaved() const;
+
 	static const Palette& GetDarkPalette();
 	static const Palette& GetLightPalette();
 	static const Palette& GetRetroBluePalette();
@@ -389,4 +394,9 @@ private:
 	uint64_t mStartTime;
 
 	float mLastClick;
+	
+	bool mSaveState;
+	bool mMarkedUnsaved;
+	int mUndoIndexFirstEdit;
+	int mUndoIndexLastSave;
 };


### PR DESCRIPTION
This PR adds an accurate method of determining whether a file has changes to be saved. Importantly, it does this without discarding undo history, and without using unnecessary memory.