### PR TITLE
fix: coordinate mismatch in `EnsureCursorVisible()` causing 4-pixel scroll margin

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -6,6 +6,6 @@ Whem contributing, please follow the following guidelines. I will keep it update
 - Please submit to the 'dev' branch first for testing, and it will be merged to 'main' if it seems to work fine. I would like try keep 'master' in a good working condition, as more and more people are using it.
 - Please send your submissions in small, well defined requests, i. e. do not accumulate many unrelated changes in one large pull request. Keep your submissions as small as possible, it will make everyone's life easier.
 - Avoid using ImGui internal since it would make the source fragile against internal changes in ImGui.
-- Try to keep the perormance high within the render function. Try to avoid doing anything which leads to memory allocations (like using temporary std::string, std::vector variables), or complex algorithm. If you really have to, try to amortise it between frames.
+- Try to keep the performance high within the render function. Try to avoid doing anything which leads to memory allocations (like using temporary std::string, std::vector variables), or complex algorithm. If you really have to, try to amortise it between frames.
 
 Thank you. :)

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1149,7 +1149,7 @@ void TextEditor::Render()
 	}
 
 
-	ImGui::Dummy(ImVec2((longest + 2), mLines.size() * mCharAdvance.y));
+	ImGui::Dummy(ImVec2((longest + 2 + 4.0f * mCharAdvance.x), mLines.size() * mCharAdvance.y));
 
 	if (mScrollToCursor)
 	{
@@ -2482,16 +2482,15 @@ void TextEditor::EnsureCursorVisible()
 	auto pos = GetActualCursorCoordinates();
 	auto len = TextDistanceToLineStart(pos);
 
-	float padY = std::min(2.0f * mCharAdvance.y, height * 0.25f);
 	float padX = std::min(4.0f * mCharAdvance.x, width * 0.25f);
 	
 	float cursorPosY = pos.mLine * mCharAdvance.y;
 	float cursorPosX = len + mTextStart;
 	
-	if (cursorPosY < scrollY + padY)
-		ImGui::SetScrollY(std::max(0.0f, cursorPosY - padY));
-	if (cursorPosY + mCharAdvance.y > scrollY + height - padY)
-		ImGui::SetScrollY(std::max(0.0f, cursorPosY + mCharAdvance.y - height + padY));
+	if (cursorPosY < scrollY)
+		ImGui::SetScrollY(std::max(0.0f, cursorPosY));
+	if (cursorPosY + mCharAdvance.y > scrollY + height)
+		ImGui::SetScrollY(std::max(0.0f, cursorPosY + mCharAdvance.y - height));
 		
 	if (cursorPosX < scrollX + padX)
 		ImGui::SetScrollX(std::max(0.0f, cursorPosX - padX));

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -2479,23 +2479,24 @@ void TextEditor::EnsureCursorVisible()
 	auto height = ImGui::GetWindowHeight();
 	auto width = ImGui::GetWindowWidth();
 
-	auto top = 1 + (int)ceil(scrollY / mCharAdvance.y);
-	auto bottom = (int)ceil((scrollY + height) / mCharAdvance.y);
-
-	auto left = (int)ceil(scrollX / mCharAdvance.x);
-	auto right = (int)ceil((scrollX + width) / mCharAdvance.x);
-
 	auto pos = GetActualCursorCoordinates();
 	auto len = TextDistanceToLineStart(pos);
 
-	if (pos.mLine < top)
-		ImGui::SetScrollY(std::max(0.0f, (pos.mLine - 1) * mCharAdvance.y));
-	if (pos.mLine > bottom - 4)
-		ImGui::SetScrollY(std::max(0.0f, (pos.mLine + 4) * mCharAdvance.y - height));
-	if (len + mTextStart < left + 4)
-		ImGui::SetScrollX(std::max(0.0f, len + mTextStart - 4));
-	if (len + mTextStart > right - 4)
-		ImGui::SetScrollX(std::max(0.0f, len + mTextStart + 4 - width));
+	float padY = std::min(2.0f * mCharAdvance.y, height * 0.25f);
+	float padX = std::min(4.0f * mCharAdvance.x, width * 0.25f);
+	
+	float cursorPosY = pos.mLine * mCharAdvance.y;
+	float cursorPosX = len + mTextStart;
+	
+	if (cursorPosY < scrollY + padY)
+		ImGui::SetScrollY(std::max(0.0f, cursorPosY - padY));
+	if (cursorPosY + mCharAdvance.y > scrollY + height - padY)
+		ImGui::SetScrollY(std::max(0.0f, cursorPosY + mCharAdvance.y - height + padY));
+		
+	if (cursorPosX < scrollX + padX)
+		ImGui::SetScrollX(std::max(0.0f, cursorPosX - padX));
+	if (cursorPosX > scrollX + width - padX)
+		ImGui::SetScrollX(std::max(0.0f, cursorPosX - width + padX));
 }
 
 int TextEditor::GetPageSize() const


### PR DESCRIPTION
**Issue:** in `TextEditor::EnsureCursorVisible()` where typing near the horizontal edges of the window would cause the view to scroll by exactly 1 character per keystroke, effectively pinning the cursor to the physical edge of the editor view.

### The Bug
The previous implementation mixed up character column indices and physical pixel floats when attempting to calculate padding bounds:

1. `len` (from `TextDistanceToLineStart`) correctly returned physical **pixels** (`float`).
2. `left` and `right` were calculated by dividing scroll dimensions by `mCharAdvance.x`, returning **character columns** (`int`).
3. The comparison `len + mTextStart < left + 4` thus incorrectly compared pixels directly to character columns.
4. Furthermore, `ImGui::SetScrollX()` expects a pixel value. By calling `ImGui::SetScrollX(... - 4)`, the logic intended to subtract a margin of 4 characters, but mathematically subtracted exactly 4 physical pixels instead. 

### The Fix
This PR fully normalizes the `EnsureCursorVisible` logic to use consistent, floating-point pixel math for all boundary and padding calculations.
- It introduces proper pixel-aware horizontal padding (`padX` = 4 characters).
- It removes arbitrary vertical padding, allowing the cursor to rest naturally at the top/bottom edges of the window without forcing unnecessary vertical scrolling.
- It fixes a bug where `ImGui::Dummy` (which defines the maximum horizontal scroll bounds) did not account for padding. By adding the horizontal padding to the Dummy width, it ensures that padding is maintained even when typing on the longest line of the document.
- It bounds the padding dynamically via `std::min(..., width * 0.25f)` to ensure that if the editor window is resized to be extremely small, the padding doesn't mathematically overlap and cause the scroll position to oscillate.

## Testing
- Verified on a standalone integration: Typing continuously towards the right margin now smoothly scrolls the view while maintaining a comfortable, properly calculated 4-character margin ahead of the cursor.
- Verified that horizontal padding is correctly applied even on the absolute longest line of the document.
- Ensured no new ImGui internals are called and no memory is allocated.
